### PR TITLE
should correctly follow symbolic links on windows 

### DIFF
--- a/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/TemplateDrivenMultiBranchProject.java
+++ b/src/main/java/com/github/mjdetullio/jenkins/plugins/multibranch/TemplateDrivenMultiBranchProject.java
@@ -712,7 +712,7 @@ public abstract class TemplateDrivenMultiBranchProject<P extends AbstractProject
     private static List<File> getConfigFiles(File dir) throws IOException {
         List<File> files = new ArrayList<>();
 
-        File[] contents = dir.listFiles();
+        File[] contents = dir.getCanonicalPath().listFiles();
         if (null == contents) {
             throw new IOException("Tried to treat '" + dir + "' as a directory, but could not get a listing");
         }


### PR DESCRIPTION
crash:

Caused by: java.io.IOException: Tried to treat 'c:\jenkins_home\jobs\softthinks_github\jobs\stoneapi\branches\update-meteor-1.4\lastStable' as a directory, but could not get a listing
	at com.github.mjdetullio.jenkins.plugins.multibranch.TemplateDrivenMultiBranchProject.getConfigFiles(TemplateDrivenMultiBranchProject.java:717)
	at com.github.mjdetullio.jenkins.plugins.multibranch.TemplateDrivenMultiBranchProject.getConfigFiles(TemplateDrivenMultiBranchProject.java:732)
	at com.github.mjdetullio.jenkins.plugins.multibranch.TemplateDrivenMultiBranchProject.getConfigFiles(TemplateDrivenMultiBranchProject.java:732)
	at com.github.mjdetullio.jenkins.plugins.multibranch.TemplateDrivenMultiBranchProject.getConfigFiles(TemplateDrivenMultiBranchProject.java:732)
	at com.github.mjdetullio.jenkins.plugins.multibranch.TemplateDrivenMultiBranchProject.getConfigFiles(TemplateDrivenMultiBranchProject.java:732)
	at com.github.mjdetullio.jenkins.plugins.multibranch.TemplateDrivenMultiBranchProject.getConfigFiles(TemplateDrivenMultiBranchProject.java:732)
	at com.github.mjdetullio.jenkins.plugins.multibranch.TemplateDrivenMultiBranchProject.getConfigFiles(TemplateDrivenMultiBranchProject.java:732)
	at com.github.mjdetullio.jenkins.plugins.multibranch.TemplateDrivenMultiBranchProject.migrate(TemplateDrivenMultiBranchProject.java:758)